### PR TITLE
Export "other rights basis" to altrender when present #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ _Rights Statements_
 
 ## Tests
 
-Run the backend tests via: 
+Run the backend tests from the application root directory with: 
 
 ```
-./build/run backend:test -Dspec="../../plugins/jpca_rights_statement"
+./build/run backend:test:plugin -Dexample='JPCA EAD export mappings'
 ```

--- a/backend/model/jpca_ead_exporter.rb
+++ b/backend/model/jpca_ead_exporter.rb
@@ -7,16 +7,22 @@ class EADSerializer < ASpaceExport::Serializer
 
   def serialize_rights(data, xml, fragments)
     data.rights_statements.each do |rts_stmt|
-      xml.userestrict({ id: "aspace_#{rts_stmt['identifier']}", type: rts_stmt['rights_type'] }) {
+
+      rts_atts = {}
+      rts_atts['id'] = "aspace_#{rts_stmt['identifier']}"
+      rts_atts['type'] = rts_stmt['rights_type']
+      rts_atts['altrender'] = rts_stmt['other_rights_basis'] unless rts_stmt.dig('other_rights_basis').nil?
+
+      xml.userestrict(rts_atts) {
         xml.head('Rights Statement')
 
         rts_stmt['notes'].each do |note|
 
-          atts = {}
-          atts['type'] = note['type']
-          atts['audience'] = 'internal' if note['publish'] === false
+          note_atts = {}
+          note_atts['type'] = note['type']
+          note_atts['audience'] = 'internal' if note['publish'] === false
 
-          xml.note(atts) {
+          xml.note(note_atts) {
             xml.p {
               note['content'].each do |c|
                 sanitize_mixed_content(c, xml, fragments)

--- a/backend/spec/export_ead_jpca_overrides_spec.rb
+++ b/backend/spec/export_ead_jpca_overrides_spec.rb
@@ -15,12 +15,14 @@ describe 'JPCA EAD export mappings' do
   def load_export_fixtures
     @published_note = build(:json_note_rights_statement, publish: true)
     @unpublished_note = build(:json_note_rights_statement, publish: false)
+    other_opts = { rights_type: 'other', other_rights_basis: 'policy', start_date: generate(:yyyy_mm_dd) }
 
     resource = create(:json_resource,
                       :publish => true,
                       :rights_statements => [build(:json_rights_statement,
                                                    notes: [@published_note,
-                                                           @unpublished_note])]
+                                                           @unpublished_note]),
+                                             build(:json_rights_statement, other_opts)]
                       )
 
     @resource = JSONModel(:resource).find(resource.id)
@@ -30,7 +32,8 @@ describe 'JPCA EAD export mappings' do
                               :publish => true,
                               :rights_statements => [build(:json_rights_statement,
                                                            notes: [@published_note,
-                                                                   @unpublished_note])]
+                                                                   @unpublished_note]),
+                                                     build(:json_rights_statement, other_opts)]
                               )
   end
 
@@ -109,6 +112,18 @@ describe 'JPCA EAD export mappings' do
           expect(note.at_xpath("@type").content).to match(@published_note.type)
         end
       end
+
+      it 'exports other rights statement to altrender' do
+        expect(doc.at_xpath("/ead/archdesc/userestrict[@type='other']").attributes).
+          to include('altrender')
+        expect(doc.at_xpath("/ead/archdesc/userestrict[@altrender]/@altrender").content).
+          to match('policy')
+      end
+
+      it 'does not export altrender attribute for non-other type rights statements' do
+        expect(doc.at_xpath("/ead/archdesc/userestrict[@type='copyright']").attributes).
+          not_to include('altrender')
+      end
     end
   end
 
@@ -157,6 +172,18 @@ describe 'JPCA EAD export mappings' do
           expect(note.content).to match(@published_note.content.join(''))
           expect(note.at_xpath("@type").content).to match(@published_note.type)
         end
+      end
+
+      it 'exports other rights statement to altrender' do
+        expect(doc.at_xpath("/ead/archdesc/dsc/c/userestrict[@type='other']").attributes).
+          to include('altrender')
+        expect(doc.at_xpath("/ead/archdesc/dsc/c/userestrict[@altrender]/@altrender").content).
+          to match('policy')
+      end
+
+      it 'does not export altrender attribute for non-other type rights statements' do
+        expect(doc.at_xpath("/ead/archdesc/dsc/c/userestrict[@type='copyright']").attributes).
+          not_to include('altrender')
       end
     end
   end

--- a/backend/spec/export_ead_jpca_overrides_spec.rb
+++ b/backend/spec/export_ead_jpca_overrides_spec.rb
@@ -113,7 +113,7 @@ describe 'JPCA EAD export mappings' do
         end
       end
 
-      it 'exports other rights statement to altrender' do
+      it 'exports other rights basis to altrender' do
         expect(doc.at_xpath("/ead/archdesc/userestrict[@type='other']").attributes).
           to include('altrender')
         expect(doc.at_xpath("/ead/archdesc/userestrict[@altrender]/@altrender").content).
@@ -174,7 +174,7 @@ describe 'JPCA EAD export mappings' do
         end
       end
 
-      it 'exports other rights statement to altrender' do
+      it 'exports other rights basis to altrender' do
         expect(doc.at_xpath("/ead/archdesc/dsc/c/userestrict[@type='other']").attributes).
           to include('altrender')
         expect(doc.at_xpath("/ead/archdesc/dsc/c/userestrict[@altrender]/@altrender").content).


### PR DESCRIPTION
## Description
Exports "other rights basis" dropdown value to `altrender` attribute of `userestrict` if present.

## Related GitHub Issue
#3

## Testing
Rspec tests added and passing in CI.

## Screenshot(s):

Other typed rights statement like:
<img width="842" alt="Screenshot 2025-01-10 at 1 22 34 PM" src="https://github.com/user-attachments/assets/ead0cae8-1209-4e69-81ec-2a415b1a64a8" />

Exports as:
<img width="711" alt="Screenshot 2025-01-10 at 1 23 19 PM" src="https://github.com/user-attachments/assets/1b27c1d5-71c9-4b15-b3a5-05d086fc2e1d" />

## Checklist

- [x] ✔️ Have you assigned at least one reviewer?
- [x] 🔗 Have you referenced any issues this PR will close?
- [x] ⬇️ Have you merged the latest upstream changes into your branch? 
- [x] 🧪 Have you added tests to cover these changes?  If not, why:
- [x] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:
- [x] 📘 Have you updated/added any relevant readmes/comments in the codebase?
- [x] 📚 Have you updated/added any external documentation (e.g. Confluence)?
