### PR TITLE
[FEATURE] To align with existing EAD export overrides for Getty, remo…

### DIFF
--- a/backend/model/jpca_ead_exporter.rb
+++ b/backend/model/jpca_ead_exporter.rb
@@ -9,7 +9,7 @@ class EADSerializer < ASpaceExport::Serializer
     data.rights_statements.each do |rts_stmt|
 
       rts_atts = {}
-      rts_atts['id'] = "aspace_#{rts_stmt['identifier']}"
+      rts_atts['id'] = rts_stmt['identifier']
       rts_atts['type'] = rts_stmt['rights_type']
       rts_atts['altrender'] = rts_stmt['other_rights_basis'] unless rts_stmt.dig('other_rights_basis').nil?
 

--- a/backend/spec/export_ead_jpca_overrides_spec.rb
+++ b/backend/spec/export_ead_jpca_overrides_spec.rb
@@ -72,7 +72,7 @@ describe 'JPCA EAD export mappings' do
 
       it 'exports rights_statements to <userestrict>' do
         expect(doc.at_xpath("/ead/archdesc/userestrict/@id").content).
-          to match("aspace_#{@resource.rights_statements.first['identifier']}")
+          to match(@resource.rights_statements.first['identifier'])
         expect(doc.at_xpath("/ead/archdesc/userestrict/@type").content).
           to match(@resource.rights_statements.first['rights_type'])
         expect(doc.at_xpath("/ead/archdesc/userestrict/head").content).
@@ -133,7 +133,7 @@ describe 'JPCA EAD export mappings' do
 
       it 'exports rights_statements to <userestrict>' do
         expect(doc.at_xpath("/ead/archdesc/dsc/c/userestrict/@id").content).
-          to match("aspace_#{@archival_object.rights_statements.first['identifier']}")
+          to match(@archival_object.rights_statements.first['identifier'])
         expect(doc.at_xpath("/ead/archdesc/dsc/c/userestrict/@type").content).
           to match(@archival_object.rights_statements.first['rights_type'])
         expect(doc.at_xpath("/ead/archdesc/dsc/c/userestrict/head").content).


### PR DESCRIPTION
…ve the "aspace_" from userestrict EAD ID attributes #5

## Description
Updates the ead export to remove the prepended `aspace_` from the id attribute per the issue request.

## Related GitHub Issue
Closes #5 

## Testing
Relevant tests updated and passing.

## Screenshot(s):
New exports look like:
```
  <userestrict altrender="donor" id="a9f056dd74364254661fe166887a70f8" type="other">
    <head>Rights Statement</head>
    <note type="additional_information">
      <p>Additional info note</p>
    </note>
    <list>
      <item>
        <date normal="2024-11-01" type="start"/>
      </item>
    </list>
  </userestrict>
```

## Checklist

- [x] ✔️ Have you assigned at least one reviewer?
- [x] 🔗 Have you referenced any issues this PR will close?
- [x] ⬇️ Have you merged the latest upstream changes into your branch? 
- [x] 🧪 Have you added tests to cover these changes?  If not, why:
- [x] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:
- [x] 📘 Have you updated/added any relevant readmes/comments in the codebase?
- [x] 📚 Have you updated/added any external documentation (e.g. Confluence)?
